### PR TITLE
Add support for SQL::Abstracts "returning" option for insert

### DIFF
--- a/lib/SQL/Abstract/Plugin/InsertMulti.pm
+++ b/lib/SQL/Abstract/Plugin/InsertMulti.pm
@@ -42,6 +42,12 @@ sub _insert_multi {
         $table, $sql,
     );
 
+    if ($opts->{returning}) {
+        my ($s, @b) = $self->_insert_returning($opts);
+        $sql .= $s;
+        push @bind, @b;
+    }
+
     return ( $sql, @bind );
 }
 

--- a/t/02_insert_multi.t
+++ b/t/02_insert_multi.t
@@ -108,6 +108,24 @@ subtest "insert_multi" => sub {
             );
         } "ARRAYREFREF";
     };
+
+    subtest 'with returning option' => sub {
+        my ($stmt, @bind) = $sql->insert_multi(
+            'example',
+            [
+                +{ foo => 'a', bar => 'b' },
+                +{ foo => 'c', bar => 'd' }
+            ],
+            { returning => [qw(foo bar)] }
+        );
+
+        is (
+            $stmt,
+            q|INSERT INTO example ( bar, foo ) VALUES ( ?, ? ), ( ?, ? ) RETURNING foo, bar|
+        );
+
+        is_deeply(\@bind, [qw(b a d c)]);
+    };
 };
 
 subtest "update_multi" => sub {


### PR DESCRIPTION
This patch handles the insert `returning` option (from SQL::Abstract).